### PR TITLE
check for null image

### DIFF
--- a/includes/classes/ajax/zcAjaxInstantSearch.php
+++ b/includes/classes/ajax/zcAjaxInstantSearch.php
@@ -177,7 +177,7 @@ class zcAjaxInstantSearch extends base
                     'type'  => $type,
                     'id'    => $id,
                     'name'  => $name,
-                    'img'   => $img,
+                    'img'   => ($img ?? ''),
                     'model' => $model,
                     'mtch'  => $totalMatches,
                     'views' => $views,


### PR DESCRIPTION
product and category image can be null if they have never been set, provoking

> --> PHP Deprecated: strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in \includes\classes\ajax\zcAjaxInstantSearch.php on line 201.

Related
https://github.com/zencart/zencart/issues/4962

